### PR TITLE
Revert "Try to map external port the same as internal port"

### DIFF
--- a/natpmp.go
+++ b/natpmp.go
@@ -111,13 +111,6 @@ func (n *natpmpNAT) AddPortMapping(protocol string, internalPort int, descriptio
 		}
 	}
 
-	// try to map external port the same as internal port
-	_, err = n.c.AddPortMapping(protocol, internalPort, internalPort, timeoutInSeconds)
-	if err == nil {
-		n.ports[internalPort] = internalPort
-		return internalPort, nil
-	}
-
 	for i := 0; i < 3; i++ {
 		externalPort := randomPort()
 		_, err = n.c.AddPortMapping(protocol, internalPort, externalPort, timeoutInSeconds)

--- a/upnp.go
+++ b/upnp.go
@@ -264,12 +264,6 @@ func (u *upnp_NAT) AddPortMapping(protocol string, internalPort int, description
 		}
 	}
 
-	// try to map external port the same as internal port
-	err = u.c.AddPortMapping("", uint16(internalPort), mapProtocol(protocol), uint16(internalPort), ip.String(), true, description, timeoutInSeconds)
-	if err == nil {
-		return internalPort, nil
-	}
-
 	for i := 0; i < 3; i++ {
 		externalPort := randomPort()
 		err = u.c.AddPortMapping("", uint16(externalPort), mapProtocol(protocol), uint16(internalPort), ip.String(), true, description, timeoutInSeconds)


### PR DESCRIPTION
This reverts commit 3fa58ced20b2ff6110ae7eca6c22e18c06c8da6f.

Its safer to just pick a random port. Unfortunately, some NATs (e.g., mine) suck and will happily map a port that's already been mapped elsewhere (e.g., in the port forwarding config).

While this patch does the _nice_ thing, it was mostly cosmetic.