### PR TITLE
fix: really obey the context

### DIFF
--- a/nat.go
+++ b/nat.go
@@ -70,6 +70,9 @@ func DiscoverNATs(ctx context.Context) <-chan NAT {
 				if !ok {
 					natpmp = nil
 				}
+			case <-ctx.Done():
+				// timeout.
+				return
 			}
 			if ok {
 				select {


### PR DESCRIPTION
The internal nat discovery logic doesn't properly propagate the context.