### PR TITLE
pass a context to DiscoverGateway

### DIFF
--- a/nat.go
+++ b/nat.go
@@ -85,10 +85,7 @@ func DiscoverNATs(ctx context.Context) <-chan NAT {
 }
 
 // DiscoverGateway attempts to find a gateway device.
-func DiscoverGateway() (NAT, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
+func DiscoverGateway(ctx context.Context) (NAT, error) {
 	var nats []NAT
 	for nat := range DiscoverNATs(ctx) {
 		nats = append(nats, nat)


### PR DESCRIPTION
This will allow us to clean up the mess in https://github.com/libp2p/go-libp2p/blob/621eafcecde611b27bbb42dda4b8bbc97b66e907/p2p/host/basic/natmgr.go#L76-L89 and get rid of `goprocess`.