### PR TITLE
fix: remove `GetNATRSIPStatus` check

### DIFF
--- a/upnp.go
+++ b/upnp.go
@@ -43,12 +43,9 @@ func discoverUPNP_IG1(ctx context.Context) <-chan NAT {
 						RootDevice: dev.Root,
 						Service:    srv,
 					}}
-					_, isNat, err := client.GetNATRSIPStatusCtx(ctx)
-					if err == nil && isNat {
-						select {
-						case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-IP1)", dev.Root}:
-						case <-ctx.Done():
-						}
+					select {
+					case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-IP1)", dev.Root}:
+					case <-ctx.Done():
 					}
 
 				case internetgateway1.URN_WANPPPConnection_1:
@@ -57,14 +54,10 @@ func discoverUPNP_IG1(ctx context.Context) <-chan NAT {
 						RootDevice: dev.Root,
 						Service:    srv,
 					}}
-					_, isNat, err := client.GetNATRSIPStatusCtx(ctx)
-					if err == nil && isNat {
-						select {
-						case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-PPP1)", dev.Root}:
-						case <-ctx.Done():
-						}
+					select {
+					case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-PPP1)", dev.Root}:
+					case <-ctx.Done():
 					}
-
 				}
 			})
 		}
@@ -100,12 +93,9 @@ func discoverUPNP_IG2(ctx context.Context) <-chan NAT {
 						RootDevice: dev.Root,
 						Service:    srv,
 					}}
-					_, isNat, err := client.GetNATRSIPStatusCtx(ctx)
-					if err == nil && isNat {
-						select {
-						case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP1)", dev.Root}:
-						case <-ctx.Done():
-						}
+					select {
+					case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP1)", dev.Root}:
+					case <-ctx.Done():
 					}
 
 				case internetgateway2.URN_WANIPConnection_2:
@@ -114,12 +104,9 @@ func discoverUPNP_IG2(ctx context.Context) <-chan NAT {
 						RootDevice: dev.Root,
 						Service:    srv,
 					}}
-					_, isNat, err := client.GetNATRSIPStatusCtx(ctx)
-					if err == nil && isNat {
-						select {
-						case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP2)", dev.Root}:
-						case <-ctx.Done():
-						}
+					select {
+					case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP2)", dev.Root}:
+					case <-ctx.Done():
 					}
 
 				case internetgateway2.URN_WANPPPConnection_1:
@@ -128,12 +115,9 @@ func discoverUPNP_IG2(ctx context.Context) <-chan NAT {
 						RootDevice: dev.Root,
 						Service:    srv,
 					}}
-					_, isNat, err := client.GetNATRSIPStatusCtx(ctx)
-					if err == nil && isNat {
-						select {
-						case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-PPP1)", dev.Root}:
-						case <-ctx.Done():
-						}
+					select {
+					case res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-PPP1)", dev.Root}:
+					case <-ctx.Done():
 					}
 
 				}


### PR DESCRIPTION
In my operating environment, I found that tailscale and qBittorrent can perform port mapping through UPnP, but libp2p cannot.

After investigation, I found that libp2p has an extra step to get the `GetNATRSIPStatus` status check compared to other UPnP programs. This step has problems on my router.

I analyzed the UPnP data packets of different routers and found that `GetNATRSIPStatus` is not enabled on all routers. However, these routers have the `AddPortMapping`/`DeletePortMapping`/`GetExternalIPAddress` capabilities, so `GetNATRSIPStatus` seems to be less important here:
- TP-Link:
![image](https://github.com/user-attachments/assets/2228eb4b-5495-4a89-bcca-1e9f18d09112)

- OpenWRT:
![image](https://github.com/user-attachments/assets/6e11b15c-7ba9-4f29-91fd-9f7b20171db4)

- Huawei:
![image](https://github.com/user-attachments/assets/88ebfed9-7af8-4a9e-b472-0d28c0e5c350)
